### PR TITLE
update symbols server url

### DIFF
--- a/scrapedebs.py
+++ b/scrapedebs.py
@@ -35,7 +35,7 @@ def print(*a, **b):
     with print_lock:
         p(*a, **b)
 
-SYMBOL_SERVER_URL = 'https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/'
+SYMBOL_SERVER_URL = 'https://symbols.mozilla.org/'
 MISSING_SYMBOLS_URL = 'https://crash-analysis.mozilla.com/crash_analysis/{date}/{date}-missing-symbols.txt'
 
 def server_has_file(filename):


### PR DESCRIPTION
scrapedebs is accessing the public symbols AWS S3 bucket directly rather than going through the Mozilla Symbols Server and getting redirected. We're planning to migrate to GCP and after we migrate, there won't be any AWS S3 bucket.

This fixes scrapedebs so that it works with our current setup as well as the setup we'll have after the GCP migration.

Details: https://bugzilla.mozilla.org/show_bug.cgi?id=1831952